### PR TITLE
add nicer seperation between variables and the expression

### DIFF
--- a/truthtable.py
+++ b/truthtable.py
@@ -258,7 +258,7 @@ for row in range(2**len(variables)):
     rows.append((varval, result, parts))
 
 out = "\\begin{tabular}{|"
-out += "c|" * len(variables) + "c"*(len(parts)) + "|} \\hline\n"
+out += "c|" * len(variables) + "|" + "c"*(len(parts)) + "|} \\hline\n"
 
 for var in variables:
     out += "$" + var + "$&"


### PR DESCRIPTION
With this change the default will look like this:

![preview](https://user-images.githubusercontent.com/2546622/48085954-f21fa080-e1fb-11e8-8a8e-e62bd78d9be8.png)

Pay attention to the nice double vline seperating the variables and the expression being evaluated.